### PR TITLE
feat(login): Safer login cookie

### DIFF
--- a/_functions.php
+++ b/_functions.php
@@ -368,17 +368,15 @@ function getforminput($text)
 
 systeminc('login');
 
-if ($loggedin === false) {
-    if (isset($_COOKIE['language'])) {
-        $_language->setLanguage($_COOKIE['language']);
-    } elseif (isset($_SESSION['language'])) {
-        $_language->setLanguage($_SESSION['language']);
-    } elseif ($autoDetectLanguage) {
-        $lang = detectUserLanguage();
-        if (!empty($lang)) {
-            $_language->setLanguage($lang);
-            $_SESSION['language'] = $lang;
-        }
+if (isset($_COOKIE['language'])) {
+    $_language->setLanguage($_COOKIE['language']);
+} elseif (isset($_SESSION['language'])) {
+    $_language->setLanguage($_SESSION['language']);
+} elseif ($autoDetectLanguage) {
+    $lang = detectUserLanguage();
+    if (!empty($lang)) {
+        $_language->setLanguage($lang);
+        $_SESSION['language'] = $lang;
     }
 }
 

--- a/_functions.php
+++ b/_functions.php
@@ -366,12 +366,6 @@ function getforminput($text)
 
 // -- LOGIN -- //
 
-$login_per_cookie = false;
-if (isset($_COOKIE['ws_auth']) && !isset($_SESSION['ws_auth'])) {
-    $login_per_cookie = true;
-    $_SESSION['ws_auth'] = $_COOKIE['ws_auth'];
-}
-
 systeminc('login');
 
 if ($loggedin === false) {
@@ -386,11 +380,6 @@ if ($loggedin === false) {
             $_SESSION['language'] = $lang;
         }
     }
-}
-
-if ($login_per_cookie) {
-    $ll = mysqli_fetch_array(safe_query("SELECT lastlogin FROM " . PREFIX . "user WHERE userID='$userID'"));
-    $_SESSION['ws_lastlogin'] = $ll['lastlogin'];
 }
 
 // -- SITE VARIABLE -- //

--- a/checklogin.php
+++ b/checklogin.php
@@ -73,7 +73,7 @@ if (mysqli_num_rows($get) == 0) {
                 $login = 0;
                 if ($ws_pwd == $ds[ 'password' ]) {
                     //session
-                    $_SESSION[ 'ws_auth' ] = $ds[ 'userID' ] . ":" . $ws_pwd;
+                    $_SESSION[ 'ws_user' ] = $ds[ 'userID' ];
                     $_SESSION[ 'ws_lastlogin' ] = $ds[ 'lastlogin' ];
                     $_SESSION[ 'referer' ] = $_SERVER[ 'HTTP_REFERER' ];
                     //remove sessiontest variable
@@ -81,27 +81,8 @@ if (mysqli_num_rows($get) == 0) {
                         unset($_SESSION[ 'ws_sessiontest' ]);
                     }
                     //cookie
-                    $cookieName = "ws_auth";
-                    $cookieValue = $ds[ 'userID' ] . ":" . $ws_pwd;
-                    $cookieExpire = time() + ($sessionduration * 60 * 60);
-                    if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
-                        $cookieInfo = session_get_cookie_params();
-                        setcookie(
-                            $cookieName,
-                            $cookieValue,
-                            $cookieExpire,
-                            $cookieInfo[ 'path' ],
-                            $cookieInfo[ 'domain' ],
-                            $cookieInfo[ 'secure' ],
-                            true
-                        );
-                    } else {
-                        setcookie($cookieName, $cookieValue, $cookieExpire);
-                    }
-                    unset($cookieName);
-                    unset($cookieValue);
-                    unset($cookieExpire);
-                    unset($cookieInfo);
+                    \webspell\LoginCookie::set('ws_auth', $_SESSION[ 'ws_user' ], $sessionduration * 60 * 60);
+                    
                     //Delete visitor with same IP from whoisonline
                     safe_query("DELETE FROM " . PREFIX . "whoisonline WHERE ip='" . $GLOBALS[ 'ip' ] . "'");
                     //Delete IP from failed logins

--- a/install/functions.php
+++ b/install/functions.php
@@ -2433,6 +2433,16 @@ function update420_430()
     mysqli_query($_database, "INSERT INTO `" . PREFIX . "modrewrite` (`regex`, `link`, `fields`, `replace_regex`, `replace_result`, `rebuild_regex`, `rebuild_result`) VALUES('whoisonline/{sort}/{type}.html','index.php?site=whoisonline&sort={sort}&type={type}','a:2:{s:4:\"sort\";s:6:\"string\";s:4:\"type\";s:6:\"string\";}','index\\\\.php\\\\?site=whoisonline[&|&amp;]*sort=(\\\\w*?)[&|&amp;]*type=(\\\\w*?)','whoisonline/$3/$4.html','whoisonline\\\\/(\\\\w*?)\\\\/(\\\\w*?)\\\\.html','index.php?site=whoisonline&sort=$1&type=$2')");
     mysqli_query($_database, "ALTER TABLE `" . PREFIX . "forum_ranks` ADD `special` INT(1) NULL DEFAULT '0'");
     mysqli_query($_database, "ALTER TABLE `" . PREFIX . "user` ADD `special_rank` INT(11) NULL DEFAULT '0'");
+    
+/* Create cookies table */
+    mysqli_query($_database, "DROP TABLE IF EXISTS `" . PREFIX . "cookies`");
+    mysqli_query($_database, "CREATE TABLE `" . PREFIX . "cookies` (
+  `userID` int(11) NOT NULL,
+  `cookie` binary(64) NOT NULL,
+  `expiration` int(14) NOT NULL,
+  PRIMARY KEY (`userID`, `cookie`),
+  INDEX (`expiration`)
+    )");
 
     updateMySQLConfig();
 }

--- a/logout.php
+++ b/logout.php
@@ -25,8 +25,9 @@
 ##########################################################################
 */
 
-session_name('ws_session');
-session_start();
+include("_mysql.php");
+include("_settings.php");
+include("_functions.php");
 
 // unset session variables
 $_SESSION = array();
@@ -39,28 +40,6 @@ if (isset($_COOKIE[ session_name() ])) {
 session_destroy();
 
 // remove login cookie
-if (isset($_COOKIE[ 'ws_auth' ])) {
-    $cookieName = "ws_auth";
-    $cookieValue = '';
-    $cookieExpire = time() - (24 * 60 * 60);
-    if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
-        $cookieInfo = session_get_cookie_params();
-        setcookie(
-            $cookieName,
-            $cookieValue,
-            $cookieExpire,
-            $cookieInfo[ 'path' ],
-            $cookieInfo[ 'domain' ],
-            $cookieInfo[ 'secure' ],
-            true
-        );
-    } else {
-        setcookie($cookieName, $cookieValue, $cookieExpire);
-    }
-    unset($cookieName);
-    unset($cookieValue);
-    unset($cookieExpire);
-    unset($cookieInfo);
-}
+webspell\LoginCookie::clear('ws_auth');
 
 header("Location: index.php");

--- a/myprofile.php
+++ b/myprofile.php
@@ -327,7 +327,7 @@ if (!$userID) {
             $newmd5pwd = generatePasswordHash(stripslashes($pwd1));
             safe_query("UPDATE " . PREFIX . "user SET password='" . $newmd5pwd . "' WHERE userID='" . $userID . "'");
             //logout
-            unset($_SESSION['ws_auth']);
+            unset($_SESSION['ws_user']);
             unset($_SESSION['ws_lastlogin']);
             session_destroy();
 

--- a/src/login.php
+++ b/src/login.php
@@ -25,40 +25,202 @@
 ##########################################################################
 */
 
-global $userID, $loggedin, $_language;
+namespace webspell;
+
+/**
+ * Somewhat secure login cookie (at the very least more secure than the previous
+ * implementation).
+ * 
+ * This implementation generates a random key for each login and stores a 
+ * hash of that key in the database. Because the keys are random, the database 
+ * entries are hashed and the tokens expire after a certain amount of time, 
+ * forging login cookies becomes rather hard.
+ */
+class LoginCookie
+{
+    private static function generateHash($key)
+    {
+        return hash('sha512', $key, true);
+    }
+  
+    /**
+     * Generate a cookie key. Optionally, a length in bytes can be specified,
+     * which defaults to 64.
+     * Note that on some systems, this function will not produce
+     * cryptographically strong keys due to openssl_random_pseudo_bytes not 
+     * being available.
+     */
+    private static function generateKey($length = 64)
+    {
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            $key = openssl_random_pseudo_bytes($length);
+        } else {
+            $key = '';
+            while ($length --> 0) {
+                $key .= pack('C', mt_rand(0, 255));
+            }
+        }
+        return $key;
+    }
+  
+    private static function setCookie($cookieName, $cookieValue, $expiration)
+    {
+        if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
+            $cookieInfo = session_get_cookie_params();
+            setcookie(
+                $cookieName,
+                $cookieValue,
+                $cookieExpire,
+                $cookieInfo[ 'path' ],
+                $cookieInfo[ 'domain' ],
+                $cookieInfo[ 'secure' ],
+                true
+            );
+        } else {
+            setcookie($cookieName, $cookieValue, $cookieExpire);
+        }
+    }
+
+    private static function checkResult(\mysqli_stmt $stmt)
+    {
+        global $userID, $loggedin, $_language;
+    
+        if ($stmt->bind_result($userID, $language, $lastlogin)
+                && $stmt->fetch()) {
+            $loggedin = true;
+            $_SESSION['ws_user'] = $userID;
+            $_SESSION['ws_lastlogin'] = $lastlogin;
+
+            if (!empty($language) && isset($_language)) {
+                if ($_language->setLanguage($language)) {
+                    $_SESSION['language'] = $language;
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a cookie that can be used for a persistent login. The login cookie
+     * is set to expire after a certain interval.
+     * The cookie has the form <userID>:<key>, with <key> being a random
+     * 64-character string (base64-encoded). Apart from setting the cookie, an
+     * entry containing the user ID, a cryptographic hash of the key and the
+     * expiration time will be inserted in the database.
+     */
+    public static function set($cookieName, $user, $expiration)
+    {
+        global $_database;
+
+        $key  = self::generateKey();
+        $hash = self::generateHash($key);
+        $cookieValue = $user . ":" . base64_encode($key);
+        $cookieExpire = $expiration > 0 ? time() + $expiration : 0;
+
+        $stmt = $_database->prepare("INSERT INTO " . PREFIX . "cookies
+                (userID, cookie, expiration) VALUES (?, ?, ?)");
+        if (false !== $stmt) {
+            $success = $stmt->bind_param("isi", $user, $hash, $cookieExpire)
+                && $stmt->execute();
+            $stmt->close();
+        }
+
+        if ($success) {
+            self::setCookie($cookieName, $cookieValue, $cookieExpire);
+        }
+    }
+
+    /**
+     * Remove a login cookie. Both the cookie on the client side and the
+     * database entry on the server side are removed. Note that this does not
+     * remove the client session.
+     */
+    public static function clear($cookieName)
+    {
+        global $_database;
+
+        $cookie = $_COOKIE[$cookieName];
+
+        if (isset($cookie)) {
+            $authent = explode(":", $cookie);
+            $user = $authent[0];
+            $key  = base64_decode($authent[1]);
+
+            $stmt = $_database->prepare("DELETE FROM " . PREFIX . "cookies
+                    WHERE `userID` = ? AND `cookie` = ?");
+            if (false !== $stmt) {
+                $stmt->bind_param('is', $user, self::generateHash($key)) &&
+                $stmt->execute();
+                $stmt->close();
+            }
+
+            $cookieValue = '';
+            $cookieExpire = time() - (24 * 60 * 60);
+            self::setCookie($cookieName, $cookieValue, $cookieExpire);
+        }
+    }
+ 
+    /**
+     * Check a login cookie. If an entry in the database exists for the cookie,
+     * log the user in and set their last login time and language preference.
+     * This also sets the ws_user session key, mapping to the user ID, to be
+     * used during the remainder of the session.
+     */
+    public static function check($cookieName)
+    {
+        global $_database, $userID;
+    
+        $authent = explode(":", $_COOKIE[$cookieName]);
+        $ws_user = $authent[0];
+        $ws_pwd  = base64_decode($authent[1]);
+
+        if (isset($ws_user, $ws_pwd)) {
+            $stmt = $_database->prepare(
+                "SELECT u.userID, language, lastlogin
+                FROM  `" . PREFIX . "cookies` c
+                INNER JOIN `" . PREFIX . "user` u
+                ON c.userID = u.userID
+                WHERE c.userID = ? AND c.cookie = ? AND c.expiration > ?"
+            );
+
+            if (false !== $stmt) {
+                $hash = self::generateHash($ws_pwd);
+                $stmt->bind_param('isi', $ws_user, $hash, time())
+                    && $stmt->execute()
+                    && self::checkResult($stmt);
+
+                $stmt->close();
+            }
+        }
+    }
+
+    /**
+     * Purge expired cookies from the database.
+     */
+    public static function purge()
+    {
+        global $_database;
+
+        $stmt = $_database->prepare(
+            "DELETE FROM " . PREFIX . "cookies WHERE `expiration` < ?"
+        );
+
+        if (false !== $stmt) {
+            $stmt->bind_param('i', time()) &&
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+}
+
+global $userID, $loggedin;
 
 $userID = 0;
 $loggedin = false;
 
-if (isset($_SESSION['ws_auth'])) {
-    if (stristr($_SESSION['ws_auth'], "userid") === false) {
-        $authent = explode(":", $_SESSION['ws_auth']);
-
-        $ws_user = $authent[0];
-        $ws_pwd = $authent[1];
-
-        if (isset($ws_user) && isset($ws_pwd)) {
-            $check = safe_query(
-                "SELECT
-                    userID, language
-                FROM
-                    " . PREFIX . "user
-                WHERE
-                    `userID`=" . (int)$ws_user . " AND
-                    `password`='" . $GLOBALS['_database']->escape_string($ws_pwd) . "'"
-            );
-
-            while ($ds = mysqli_fetch_array($check)) {
-                $loggedin = true;
-                $userID = $ds['userID'];
-                if (!empty($ds['language']) && isset($_language)) {
-                    if ($_language->setLanguage($ds['language'])) {
-                        $_SESSION['language'] = $ds['language'];
-                    }
-                }
-            }
-        }
-    } else {
-        die();
-    }
+if (isset($_SESSION['ws_user'])) {
+    $userID = $_SESSION['ws_user'];
+    $loggedin = true;
+} elseif (isset($_COOKIE['ws_auth'])) {
+    LoginCookie::purge();
+    LoginCookie::check('ws_auth');
 }

--- a/src/login.php
+++ b/src/login.php
@@ -63,7 +63,7 @@ class LoginCookie
         return $key;
     }
   
-    private static function setCookie($cookieName, $cookieValue, $expiration)
+    private static function setCookie($cookieName, $cookieValue, $cookieExpire)
     {
         if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
             $cookieInfo = session_get_cookie_params();

--- a/src/login.php
+++ b/src/login.php
@@ -116,11 +116,16 @@ class LoginCookie
         $cookieValue = $user . ":" . base64_encode($key);
         $cookieExpire = $expiration > 0 ? time() + $expiration : 0;
 
+        $success = false;
+
         $stmt = $_database->prepare("INSERT INTO " . PREFIX . "cookies
                 (userID, cookie, expiration) VALUES (?, ?, ?)");
         if (false !== $stmt) {
-            $success = $stmt->bind_param("isi", $user, $hash, $cookieExpire)
-                && $stmt->execute();
+            if ($stmt->bind_param("isi", $user, $hash, $cookieExpire)) {
+                if ($stmt->execute()) {
+                    $success = true;
+                }
+            }
             $stmt->close();
         }
 
@@ -148,8 +153,9 @@ class LoginCookie
             $stmt = $_database->prepare("DELETE FROM " . PREFIX . "cookies
                     WHERE `userID` = ? AND `cookie` = ?");
             if (false !== $stmt) {
-                $stmt->bind_param('is', $user, self::generateHash($key)) &&
-                $stmt->execute();
+                if ($stmt->bind_param('is', $user, self::generateHash($key))) {
+                    $stmt->execute();
+                }
                 $stmt->close();
             }
 
@@ -184,9 +190,11 @@ class LoginCookie
 
             if (false !== $stmt) {
                 $hash = self::generateHash($ws_pwd);
-                $stmt->bind_param('isi', $ws_user, $hash, time())
-                    && $stmt->execute()
-                    && self::checkResult($stmt);
+                if ($stmt->bind_param('isi', $ws_user, $hash, time())) {
+                    if ($stmt->execute()) {
+                        self::checkResult($stmt);
+                    }
+                }
 
                 $stmt->close();
             }
@@ -205,8 +213,9 @@ class LoginCookie
         );
 
         if (false !== $stmt) {
-            $stmt->bind_param('i', time()) &&
-            $stmt->execute();
+            if ($stmt->bind_param('i', time())) {
+                $stmt->execute();
+            }
             $stmt->close();
         }
     }

--- a/src/login.php
+++ b/src/login.php
@@ -30,10 +30,10 @@ namespace webspell;
 /**
  * Somewhat secure login cookie (at the very least more secure than the previous
  * implementation).
- * 
- * This implementation generates a random key for each login and stores a 
- * hash of that key in the database. Because the keys are random, the database 
- * entries are hashed and the tokens expire after a certain amount of time, 
+ *
+ * This implementation generates a random key for each login and stores a
+ * hash of that key in the database. Because the keys are random, the database
+ * entries are hashed and the tokens expire after a certain amount of time,
  * forging login cookies becomes rather hard.
  */
 class LoginCookie
@@ -47,7 +47,7 @@ class LoginCookie
      * Generate a cookie key. Optionally, a length in bytes can be specified,
      * which defaults to 64.
      * Note that on some systems, this function will not produce
-     * cryptographically strong keys due to openssl_random_pseudo_bytes not 
+     * cryptographically strong keys due to openssl_random_pseudo_bytes not
      * being available.
      */
     private static function generateKey($length = 64)


### PR DESCRIPTION
The current login cookie implementation uses the hash of the user's password, as stored in the database, to log a user in. That allows an attacker with a copy of the database to log into a user's account without knowing their password. Since many people re-use their password across multiple sites, this allows an attacker to log into users' accounts on all those sites.

This new implementation generates a random key on every login. A hashed version of that key is stored in the database, along with the ID of the user to whom that key belongs and an expiration time. Because a hashed version of the cookie key is stored in the database and cookie keys expire, an attacker cannot crack the key in the database within reasonable time. Because cookie keys expire, even stolen login cookies are usable for only a short timespan. And because each site generates their own cookies, cookies cannot be used across sites.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27769492%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89592638%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89592801%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27769626%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27769663%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89595553%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27769915%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89606932%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89630670%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89632102%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89672792%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89748707%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27905648%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r28045155%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-92083599%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23issuecomment-89592638%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thank%20you%20for%20your%20pull%20request.%20It%20is%20always%20greate%20to%20increase%20security.%5Cr%5Cn%5Cr%5CnFrom%20my%20side%20it%20should%20be%20merged%20as%20fast%20as%20possible%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A08%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20about%20prepared%20statements%20vs.%20safe_query%20%3F%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A11%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/706758%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/derchrisuk%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40derchrisuk%20I%20chose%20not%20to%20use%20%60safe_query%60%20because%2C%20well%2C%20it%27s%20not%20exactly%20safe.%20It%27s%20simply%20too%20easy%20to%20forget%20properly%20escaping%20any%20input%2C%20whereas%20prepared%20statements%20intrinsically%20protect%20against%20SQL%20injections%20%28if%20I%27m%20not%20mistaken%2C%20v4.2.3%20contained%20a%20very%20nice%20cookie-based%20SQL%20injection%20vulnerability%29.%20%5Cr%5Cn%5Cr%5CnSince%20login%20cookies%20do%20not%20provide%20core%20functionality%2C%20a%20database%20error%20can%20be%20ignored%20silently%20and%20the%20_Query%20Failed%21_%20error%20needs%20not%20be%20given%20by%20%60safe_query%60.%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A27%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20seem%20to%20be%20right%20about%20the%20cookie-based%20sql%20injection.%20Thanks%20for%20the%20hint%20and%20the%20fix%5E%5E%5Cr%5CnBut%20since%20we%20are%20using%20safe_query%20everywhere%20it%20should%20be%20used%20here%20also%20but%20with%20correct%20escaping%22%2C%20%22created_at%22%3A%20%222015-04-04T16%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20wouldn%27t%20it%20be%20time%20to%20start%20shifting%20away%20from%20safe_query%3F%20It%27s%20only%20a%20matter%20of%20time%20before%20a%20new%20sql%20injection%20vulnerability%20arises.%22%2C%20%22created_at%22%3A%20%222015-04-04T17%3A57%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%2C%20%7B%22body%22%3A%20%22maybe%20it%20is%20time%20to%20switch%20to%20prepared%20statements%20but%20%20this%20is%20beyond%20the%20scope%20of%20this%20pull%20request.%20so%20to%20be%20consistent%20with%20all%20other%20sql%20queries%20you%20should%20use%20safe_query.%22%2C%20%22created_at%22%3A%20%222015-04-04T18%3A05%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22Prepared%20statements%20are%20a%20good%20improvement%20over%20just%20using%20normal%20SQL%20queries%2C%20but%20they%20are%20not%20removing%20SQL%20injection%20vectors%20completely.%5Cr%5CnOur%20%60safe_query%60%20is%20also%20not%20100%25%20secure%2C%20but%20we%20have%20more%20control%20over%20the%20SQL%20we%20send%20to%20the%20DB.%5Cr%5Cn%5Cr%5CnAt%20the%20moment%20we%20are%20sticking%20to%20%60safe_query%60.%5Cr%5CnWhether%20we%20are%20going%20to%20implement%20another%20system%20is%20not%20part%20of%20the%20PR.%22%2C%20%22created_at%22%3A%20%222015-04-04T22%3A31%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/706758%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/derchrisuk%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40derchrisuk%20source%3F%20%5Cr%5Cn%5Cr%5CnI%20agree%20prepared%20statements%20are%20beyond%20the%20scope%20of%20this%20PR%20though%2C%20so%20I%27ve%20replaced%20them%20with%20%60safe_query%60%20in%2025b3bf6%22%2C%20%22created_at%22%3A%20%222015-04-05T10%3A11%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%2C%20%7B%22body%22%3A%20%22Today%20we%20found%20a%20small%20bug%20in%20language%20selection%20for%20logged%20in%20users.%5Cr%5CnThe%20language%20a%20user%20used%20is%20ignored%20when%20he%20is%20logged%20in%20and%20it%20is%20always%20uses%20page%20default%20language%5Cr%5Cn%5Cr%5CnIn%20the%20old%20version%20the%20language%20is%20set%20on%20every%20page%20request%20when%20the%20user%20is%20looked%20up%20in%20the%20database.%20in%20the%20new%20version%20only%20the%20session%20variable%20is%20set%20but%20in%20_functions.php%20it%20is%20ignored%20for%20logged%20in%20users.%5Cr%5Cn%5Cr%5Cnso%20please%20remove%5Cr%5Cn%60%60%60php%5Cr%5Cnif%20%28%24loggedin%20%3D%3D%3D%20false%29%20%7B%5Cr%5Cn%60%60%60%20%5Cr%5Cnin%20line%20371%20in%20_functions.php%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-12T16%3A02%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2025b3bf6dfc8327d5a233b310efa0c735356c7cdd%20src/login.php%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27905648%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%24expiration%20should%20be%20called%20%24cookieExpire%20or%20vise%20versa%22%2C%20%22created_at%22%3A%20%222015-04-07T18%3A23%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22Whoops%21%20I%27ve%20gotten%20too%20used%20to%20a%20compiler%20complaining%20about%20such%20things.%20Fixed.%22%2C%20%22created_at%22%3A%20%222015-04-09T08%3A54%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/login.php%3AL25-216%22%7D%2C%20%22Pull%20e56914e6fee8bef0cf9165528bacca619236e080%20src/login.php%20134%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL/pull/223%23discussion_r27769492%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%20is%20not%20needed%20to%20use%20%26%26%20header.%5Cr%5Cnto%20increase%20readability%20it%20would%20be%20nice%20if%20you%20split%20the%20lines%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A06%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20%60%26%26%60%20there%20is%20meant%20to%20not%20execute%20the%20query%20if%20%60bind_param%60%20fails%20%28the%20PHP%20docs%20provide%20awefully%20little%20information%20on%20how%20%60execute%60%20behaves%20if%20binding%20parameters%20fails%2C%20so%20better%20be%20safe%20than%20sorry%29.%5Cr%5Cn%5Cr%5CnWhich%20lines%20should%20be%20split%3F%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A19%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20i%20know%20how%20it%20behaves.%20just%20split%20it%20into%20if%28bind_param%29%20%7B%20execute%7D%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-04-04T15%3A24%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20check.%20Fixed%20in%20b614321%22%2C%20%22created_at%22%3A%20%222015-04-04T16%3A00%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7403141%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lhelsloot%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/login.php%3AL25-227%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull e56914e6fee8bef0cf9165528bacca619236e080 src/login.php 134'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL/pull/223#discussion_r27769492'>File: src/login.php:L25-227</a></b>
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> I think it is not needed to use && header.
to increase readability it would be nice if you split the lines
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> The `&&` there is meant to not execute the query if `bind_param` fails (the PHP docs provide awefully little information on how `execute` behaves if binding parameters fails, so better be safe than sorry).
Which lines should be split?
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> Yes i know how it behaves. just split it into if(bind_param) { execute} ;)
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> Oh check. Fixed in b614321
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL/pull/223#issuecomment-89592638'>General Comment</a></b>
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> Thank you for your pull request. It is always greate to increase security.
From my side it should be merged as fast as possible
- <a href='https://github.com/derchrisuk'><img border=0 src='https://avatars.githubusercontent.com/u/706758?v=3' height=16 width=16'></a> What about prepared statements vs. safe_query ?
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> @derchrisuk I chose not to use `safe_query` because, well, it's not exactly safe. It's simply too easy to forget properly escaping any input, whereas prepared statements intrinsically protect against SQL injections (if I'm not mistaken, v4.2.3 contained a very nice cookie-based SQL injection vulnerability).
Since login cookies do not provide core functionality, a database error can be ignored silently and the _Query Failed!_ error needs not be given by `safe_query`.
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> You seem to be right about the cookie-based sql injection. Thanks for the hint and the fix^^
But since we are using safe_query everywhere it should be used here also but with correct escaping
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> So wouldn't it be time to start shifting away from safe_query? It's only a matter of time before a new sql injection vulnerability arises.
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> maybe it is time to switch to prepared statements but  this is beyond the scope of this pull request. so to be consistent with all other sql queries you should use safe_query.
- <a href='https://github.com/derchrisuk'><img border=0 src='https://avatars.githubusercontent.com/u/706758?v=3' height=16 width=16'></a> Prepared statements are a good improvement over just using normal SQL queries, but they are not removing SQL injection vectors completely.
Our `safe_query` is also not 100% secure, but we have more control over the SQL we send to the DB.
At the moment we are sticking to `safe_query`.
Whether we are going to implement another system is not part of the PR.
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> @derchrisuk source?
I agree prepared statements are beyond the scope of this PR though, so I've replaced them with `safe_query` in 25b3bf6
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> Today we found a small bug in language selection for logged in users.
The language a user used is ignored when he is logged in and it is always uses page default language
In the old version the language is set on every page request when the user is looked up in the database. in the new version only the session variable is set but in _functions.php it is ignored for logged in users.
so please remove
```php
if ($loggedin === false) {
```
in line 371 in _functions.php
- [ ] <a href='#crh-comment-Pull 25b3bf6dfc8327d5a233b310efa0c735356c7cdd src/login.php 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL/pull/223#discussion_r27905648'>File: src/login.php:L25-216</a></b>
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> $expiration should be called $cookieExpire or vise versa
- <a href='https://github.com/lhelsloot'><img border=0 src='https://avatars.githubusercontent.com/u/7403141?v=3' height=16 width=16'></a> Whoops! I've gotten too used to a compiler complaining about such things. Fixed.


<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/223?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/223?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/223'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>