### PR TITLE
Fix: BBcodes get ignored in top-news

### DIFF
--- a/sc_topnews.php
+++ b/sc_topnews.php
@@ -52,12 +52,13 @@ if ($anz) {
 
     $headline = clearfromtags($message_array[ $showlang ][ 'headline' ]);
     $content = $message_array[ $showlang ][ 'message' ];
+    $content = nl2br(strip_tags($content));
 
     if (mb_strlen($content) > $maxtopnewschars) {
         $content = mb_substr($content, 0, $maxtopnewschars);
         $content .= '...';
     }
-    $content = nl2br(strip_tags($content));
+    $content = htmloutput($content);
 
     $data_array = array();
     $data_array['$topnewsID'] = $topnewsID;

--- a/sc_topnews.php
+++ b/sc_topnews.php
@@ -52,13 +52,12 @@ if ($anz) {
 
     $headline = clearfromtags($message_array[ $showlang ][ 'headline' ]);
     $content = $message_array[ $showlang ][ 'message' ];
-    $content = nl2br(strip_tags($content));
+    $content = nl2br(strip_tags(htmloutput($content)));
 
     if (mb_strlen($content) > $maxtopnewschars) {
         $content = mb_substr($content, 0, $maxtopnewschars);
         $content .= '...';
     }
-    $content = htmloutput($content);
 
     $data_array = array();
     $data_array['$topnewsID'] = $topnewsID;


### PR DESCRIPTION
Also changed striptags to be above the maxlenght function.

close #211
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/webSPELL/webSPELL/commit/36d9f9acf797cc76d90ca4791ac02d018e790889%23commitcomment-12145749%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/commit/36d9f9acf797cc76d90ca4791ac02d018e790889%23commitcomment-12225744%22%5D%2C%20%22comments%22%3A%20%7B%22Commit%2036d9f9acf797cc76d90ca4791ac02d018e790889%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL/commit/36d9f9acf797cc76d90ca4791ac02d018e790889%23commitcomment-12145749%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22While%20i%20was%20trying%20to%20dynamicly%20calculate%20the%20proper%20content%20output%20lenght.%20I%20came%20to%20the%20conclusion%20that%20tags%20got%20cut%20off%2C%20didn%27t%20think%20about%20that.%20Anyway%20i%20resolved%20the%20problem%20at%20hand%20by%20removing%20all%20tags%20instead.%5Cr%5Cn%5Cr%5CnI%20think%20this%20solution%20is%20the%20proper%20one%2C%20sinds%20allowing%20BBcode%20will%20require%20you%20to%20write%20allot%20more%20code%20to%20prevent%20a%20cut%20before%20closing%20tags%20where%20applied%2C%20also%20images%20being%20loaded%20could%20break%20layouts.%22%2C%20%22created_at%22%3A%20%222015-07-14T00%3A49%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-07-17T13%3A52%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%2036d9f9a%20comments%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Commit 36d9f9acf797cc76d90ca4791ac02d018e790889'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL/commit/36d9f9acf797cc76d90ca4791ac02d018e790889#commitcomment-12145749'>Commit 36d9f9a comments</a></b>
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> While i was trying to dynamicly calculate the proper content output lenght. I came to the conclusion that tags got cut off, didn't think about that. Anyway i resolved the problem at hand by removing all tags instead.
I think this solution is the proper one, sinds allowing BBcode will require you to write allot more code to prevent a cut before closing tags where applied, also images being loaded could break layouts.


<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/256?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/256?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/256'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>