### PR TITLE
fix(files): check if isFileURL $url is set before parsing fixes #260

### DIFF
--- a/src/func/filesystem.php
+++ b/src/func/filesystem.php
@@ -93,8 +93,12 @@ function rm_recursive($filepath)
 
 function isFileURL($url)
 {
-    $urlInfo = parse_url($url);
-    return in_array($urlInfo['scheme'], array('ftp','http','https')) && !empty($urlInfo['path']);
+    if (!empty($url)) {
+        $urlInfo = parse_url($url);
+        return in_array($urlInfo['scheme'], array('ftp','http','https')) && !empty($urlInfo['path']);
+    } else {
+        return false;
+    }
 }
 
 function isWebURL($url)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/webSPELL/webSPELL/commit/a73cec52836fef63efb169a2c39305cfbe0e7cd0%23commitcomment-12273804%22%2C%20%22https%3A//github.com/webSPELL/webSPELL/commit/a73cec52836fef63efb169a2c39305cfbe0e7cd0%23commitcomment-12275417%22%5D%2C%20%22comments%22%3A%20%7B%22Commit%20a73cec52836fef63efb169a2c39305cfbe0e7cd0%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL/commit/a73cec52836fef63efb169a2c39305cfbe0e7cd0%23commitcomment-12273804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20does%20not%20properly%20check%20that%20the%20variable%20is%20declared%20or%20not%3F%5Cr%5Cn%5Cr%5Cn%60%60%60PHP%5Cr%5Cn%24url%20%3D%20isset%28%24url%29%20%3F%20%24url%3A%20%27%27%3B%5Cr%5Cn%5Cr%5CnOR%5Cr%5Cn%5Cr%5Cnif%28isset%28%24url%29%20%7B%5Cr%5Cn%20%20%20%20%20%24urlInfo%20%3D%20parse_url%28%24url%29%3B%5Cr%5Cn%20%20%20%20%20return%20in_array%28%24urlInfo%5B%27scheme%27%5D%2C%20array%28%27ftp%27%2C%27http%27%2C%27https%27%29%29%20%26%26%20%21empty%28%24urlInfo%5B%27path%27%5D%29%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-07-21T12%3A29%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60isset%28%29%60%20would%20also%20be%20true%20if%20%60%24url%20%3D%3D%20%27%27%60%20or%20%60%24url%20%3D%3D%20null%60%20-%20we%20don%27t%20want%20that%20here.%22%2C%20%22created_at%22%3A%20%222015-07-21T13%3A42%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%5D%2C%20%22title%22%3A%20%22Commit%20a73cec5%20comments%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Commit a73cec52836fef63efb169a2c39305cfbe0e7cd0'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL/commit/a73cec52836fef63efb169a2c39305cfbe0e7cd0#commitcomment-12273804'>Commit a73cec5 comments</a></b>
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> This does not properly check that the variable is declared or not?
```PHP
$url = isset($url) ? $url: '';
OR
if(isset($url) {
$urlInfo = parse_url($url);
return in_array($urlInfo['scheme'], array('ftp','http','https')) && !empty($urlInfo['path']);
}
```
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> `isset()` would also be true if `$url == ''` or `$url == null` - we don't want that here.


<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/263?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/263?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/263'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>