### PR TITLE
fix(bbcode): fix detection of local urls

### DIFF
--- a/src/func/bbcode.php
+++ b/src/func/bbcode.php
@@ -485,8 +485,12 @@ function cut_middle($str, $max = 50)
 function urlreplace_callback($match)
 {
     $parsed = parse_url($match[1]);
-    if (!isset($parsed['host']) && !file_exists($parsed['path'])) {
-        $url = "http://".$match[1];
+    if (!isset($parsed['host'])) {
+        if (!file_exists($parsed['path'])) {
+            $url = "http://".$match[1];
+        } else {
+            $url = $match[1];
+        }
     } elseif (!isset($parsed['scheme'])) {
         $url = "http://".$match[1];
     } else {


### PR DESCRIPTION
Fixes detection of local urls like: index.php?site=guestbook
before: http://index.php/?site=guestbook
after: index.php?site=guestbook
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/277?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/277'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>