### PR TITLE
fix(bbcode): fix flags function when called from admincenter

### DIFF
--- a/src/func/bbcode.php
+++ b/src/func/bbcode.php
@@ -170,13 +170,15 @@ function fixJavaEvents($string)
 function flags($text, $calledfrom = 'root')
 {
     global $_language;
-    $_language->readModule('bbcode', true);
 
+    $prefix = '';
     if ($calledfrom == 'admin') {
         $prefix = '../';
+        $_language->readModule('bbcode', true, true);
     } else {
-        $prefix = '';
+        $_language->readModule('bbcode', true, false);
     }
+
     $ergebnis = safe_query("SELECT * FROM `" . PREFIX . "countries`");
     while ($ds = mysqli_fetch_array($ergebnis)) {
         $text = str_ireplace(


### PR DESCRIPTION
closes #264 thanks to @svnnn
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/281?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/281'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>