### PR TITLE
Implemented strict boolean comparison

### DIFF
--- a/development/tools/find_lang_dup.php
+++ b/development/tools/find_lang_dup.php
@@ -31,7 +31,7 @@ foreach($allLangFiles as $file){
                     break;
                 }
             }
-            if($found == false){
+            if($found === false){
                 $all_keys[$key][] = array(1, $value);
             }
         }

--- a/install/ajax.php
+++ b/install/ajax.php
@@ -45,7 +45,7 @@ $_language->readModule('step6');
 header('Cache-Control: no-cache, must-revalidate');
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Content-type: application/json');
-if ($function != null) {
+if ($function !== null) {
     if (isset($_SESSION['adminname'])) $adminname = $_SESSION['adminname'];
     if (isset($_SESSION['adminpassword'])) $adminpassword = $_SESSION['adminpassword'];
     if (isset($_SESSION['adminmail'])) $adminmail = $_SESSION['adminmail'];


### PR DESCRIPTION
Implemented strict boolean comparison. The problem with loose comparison is that variables in PHP can't be declared with a specific type. 

This means that with loose boolean comparison there might be some risk of bugs produced by type juggling. 

Strict comparison requires that the two pieces of data being compared to have not only the same value, but the same type as well.

Thank you.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/webSPELL/webSPELL/pull/301?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL/pull/301'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>